### PR TITLE
Del users

### DIFF
--- a/service/telegram_service.py
+++ b/service/telegram_service.py
@@ -3,13 +3,13 @@ from crud.userstg import userstg_crud
 from permissions.permissions import check_authorization
 
 
-async def add_users(username, users=None):
+async def add_users(username, users=None, is_superuser=False, is_active=True):
     """Добавление пользователей в ДБ."""
 
     if not await check_authorization(username, True) or users is None:
         return False
 
-    users = [{'username': user, 'is_superuser': False, 'is_admin': True} for user in users.split(', ')]
+    users = [{'username': user, 'is_superuser': is_superuser, 'is_admin': True, 'is_active': is_active} for user in users.split(', ')]
 
     db = ''
     async with async_session() as session:
@@ -17,3 +17,8 @@ async def add_users(username, users=None):
             for user in users:
                 db += ' ' + (await userstg_crud.create(user, session)).username
     return db
+
+
+async def del_users():
+    """Установка пользователя из ДБ."""
+    pass


### PR DESCRIPTION
Так как речь идёт не о физическом Drop Users из Postgres, а всего лишь о переводе статуса пользователя в in_active=False, то del_user метод будет для отчистки базы данных и для этого он остаётся зарезервированным. А del_users в контексте поставленного вопроса для add_user(username, users=None, is_superuser=False, is_active=True). Т. е. появился новый аргумент в методе add_users --> is_active, который по умолчанию True и именно им при необходимости существующий  пользователь будет переводиться в состояние неактивного при установке этого параметра в False.